### PR TITLE
Update unit tests to be compatible with Moodle 3.10+

### DIFF
--- a/tests/qcat_dupe_question_merger_test.php
+++ b/tests/qcat_dupe_question_merger_test.php
@@ -22,7 +22,7 @@ defined('MOODLE_INTERNAL') || die();
 
 class qcat_dupe_question_merger_test extends \advanced_testcase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         $this->resetAfterTest();
         $this->questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
         $this->quizgenerator = $this->getDataGenerator()->get_plugin_generator('mod_quiz');


### PR DESCRIPTION
In Moodle 3.10 - Breaking change: All the "template methods" (setUp(), tearDown()...) now require to return void.
https://github.com/moodle/moodle/blob/master/lib/upgrade.txt#L772